### PR TITLE
Add support for multiple closures

### DIFF
--- a/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
+++ b/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
@@ -3,7 +3,7 @@ parser grammar GradleScript;
 options { tokenVocab=GradleScriptLexer; }
 
 script
-    :   (text|BRACE_OPEN|BRACE_CLOSE|dependencies|buildscript)* EOF
+    :   (text|dependencies|buildscript)* EOF
     ;
 
 dependencies
@@ -61,7 +61,7 @@ fileDependency
     ;
 
 closure
-    :   BRACE_OPEN (text+?|closure)+ BRACE_CLOSE
+    :   BRACE_OPEN (codeblock+?|closure)+ BRACE_CLOSE
     ;
 
 quote
@@ -70,6 +70,26 @@ quote
     ;
 
 text
+    : UNICODE_LATIN
+    | ID
+    | WS
+    | DIGIT
+    | FILE
+    | FILES
+    | EQUALS
+    | SEMI
+    | QUOTE_SINGLE
+    | QUOTE_DOUBLE
+    | BRACE_OPEN
+    | BRACE_CLOSE
+    | PARENS_OPEN
+    | PARENS_CLOSE
+    | BACKSLASH
+    | PROJECT
+    | COMMA
+    ;
+
+codeblock
     : UNICODE_LATIN
     | ID
     | WS

--- a/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
+++ b/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
@@ -3,7 +3,7 @@ parser grammar GradleScript;
 options { tokenVocab=GradleScriptLexer; }
 
 script
-    :   (text|dependencies|buildscript)* EOF
+    :   (text|BRACE_OPEN|BRACE_CLOSE|dependencies|buildscript)* EOF
     ;
 
 dependencies
@@ -61,7 +61,7 @@ fileDependency
     ;
 
 closure
-    :   BRACE_OPEN text+? BRACE_CLOSE
+    :   BRACE_OPEN (text+?|closure)+ BRACE_CLOSE
     ;
 
 quote
@@ -80,8 +80,6 @@ text
     | SEMI
     | QUOTE_SINGLE
     | QUOTE_DOUBLE
-    | BRACE_OPEN
-    | BRACE_CLOSE
     | PARENS_OPEN
     | PARENS_CLOSE
     | BACKSLASH

--- a/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
+++ b/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
@@ -166,6 +166,12 @@ final class GradleScriptSpec extends Specification {
             implementation(libs.commonsCompress) {
               because 'Better ZipFile implementation'
             }
+            
+            implementation (libs.spotify.authSdk){
+              artifact {
+                type = "aar"
+              }
+            }
 
             implementation(libs.jgit.core) {
               because 'Better than the command line git via ProcessBuilder.'
@@ -421,6 +427,7 @@ final class GradleScriptSpec extends Specification {
       "project(':platform')",
       "project(':xml-combiner')",
       'libs.commonsCompress',
+      'libs.spotify.authSdk',
       'libs.jgit.core',
       'libs.jgit.ssh.core',
       'libs.jgit.ssh.agent',


### PR DESCRIPTION
### Description
Discovered an incompatibility between my project and [gradle-dependencies-sorter](https://github.com/square/gradle-dependencies-sorter).

In my project, I have some dependencies with the artifact type declared like the following:
```groovy
dependencies {
    implementation (libs.spotify.authSdk) {
        artifact {
            type = "aar"
        }
    }
}
```

gradle-dependencies-sorter delegates the gradle script parsing to [gradle-script-grammar](https://github.com/autonomousapps/gradle-script-grammar). This repo makes an assumption that closures will be one level deep and doesn't support multiple closures for a gradle dependency.

This PR adds support for multiple closures so the example dependency above can be successfully parsed. It also adds a new `codeblock` definition that is a dupe of `text` minus the braces (required for the parser to work properly for this) in order to ensure the behavior of the parser only affected the `closure` definition.