### PR TITLE
Support `dependencies` referenced with dot syntax

### DIFF
--- a/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScriptLexer.g4
+++ b/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScriptLexer.g4
@@ -2,7 +2,7 @@ lexer grammar GradleScriptLexer;
 
 channels { WHITESPACE, COMMENTS }
 
-DEPENDENCIES: 'dependencies' WS* BRACE_OPEN;
+DEPENDENCIES: (NAME '.')* 'dependencies' WS* BRACE_OPEN;
 FILE: 'file(';
 FILES: 'files(';
 TEST_FIXTURES: 'testFixtures(';

--- a/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
+++ b/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
@@ -527,6 +527,39 @@ final class GradleScriptSpec extends Specification {
     )
   }
 
+  // https://github.com/square/gradle-dependencies-sorter/issues/153
+  def "can parse multiple dependencies blocks using dot syntax"() {
+    given:
+    def sourceFile = dir.resolve('build.gradle')
+    Files.writeString(
+      sourceFile,
+      """\
+      kotlin {
+        sourceSets {
+          commonMain.dependencies {
+            api projects.redwoodLayoutWidget
+            implementation projects.redwoodFlexbox
+            implementation projects.redwoodWidgetCompose
+          }
+        }
+        sourceSets.commonMain.dependencies {
+            implementation libs.jetbrains.compose.foundation
+        }
+      }""".stripIndent()
+    )
+
+    when:
+    def list = parseGroovyGradleScript(sourceFile)
+
+    then:
+    assertThat(list).containsExactly(
+      'projects.redwoodLayoutWidget',
+      'projects.redwoodFlexbox',
+      'projects.redwoodWidgetCompose',
+      'libs.jetbrains.compose.foundation',
+    )
+  }
+
   def "can parse dependencies with multiple closures"() {
     given:
     def sourceFile = dir.resolve('build.gradle')


### PR DESCRIPTION
This would presumably close https://github.com/square/gradle-dependencies-sorter/issues/153.

Working on this was a blast from the past with all the Redwood references 😅  I haven't done lexer stuff since working on SQLDelight, but as far as I can remember, I think this is what we want.