### PR TITLE
Expose nested/dotted/callable DSL blocks in the parse tree

### DIFF
--- a/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
+++ b/gradle-script-grammar/src/main/antlr/com/autonomousapps/grammar/gradle/GradleScript.g4
@@ -3,19 +3,21 @@ parser grammar GradleScript;
 options { tokenVocab=GradleScriptLexer; }
 
 script
-    :   (text|dependencies|buildscript)* EOF
+    :   (dependencies|buildscript|block|text)* EOF
     ;
 
+// Nested DSL blocks such as constraints { api("g:a:1") } remain separate from surrounding dependency declarations.
 dependencies
-    :   DEPENDENCIES (normalDeclaration|testFixturesDeclaration|enforcedPlatformDeclaration|platformDeclaration)* BRACE_CLOSE
+    :   DEPENDENCIES (normalDeclaration|testFixturesDeclaration|enforcedPlatformDeclaration|platformDeclaration|block)* BRACE_CLOSE
     ;
 
 buildscript
-    :   BUILDSCRIPT BRACE_OPEN (dependencies|block|sea)* BRACE_CLOSE
+    :   BUILDSCRIPT BRACE_OPEN (dependencies|block|closure|sea)* BRACE_CLOSE
     ;
 
+// Optional call arguments keep create("Database") { } available as a single block.
 block
-    :   ID BRACE_OPEN (block|sea)* BRACE_CLOSE
+    :   ID callArguments? BRACE_OPEN (dependencies|block|closure|sea)* BRACE_CLOSE
     ;
 
 normalDeclaration
@@ -65,8 +67,9 @@ fileDependency
     :   (FILE|FILES) quote? ID quote? PARENS_CLOSE
     ;
 
+// Closures stay opaque except for nested blocks such as artifact { type = "aar" }.
 closure
-    :   BRACE_OPEN (codeblock+?|closure)+ BRACE_CLOSE
+    :   BRACE_OPEN (dependencies|block|closure|codeblock)* BRACE_CLOSE
     ;
 
 quote
@@ -98,10 +101,17 @@ text
 codeblock
     : UNICODE_LATIN
     | ID
+    | NAME
     | WS
     | DIGIT
     | FILE
     | FILES
+    | TEST_FIXTURES
+    | ENFORCED_PLATFORM
+    | PLATFORM
+    | BUILDSCRIPT
+    | PATH
+    | CONFIGURATION
     | EQUALS
     | SEMI
     | QUOTE_SINGLE
@@ -114,13 +124,64 @@ codeblock
     | COMMA
     ;
 
-// Sea of crap I don't care about
+// Tokens from statements such as enabled = true are ignored while walking a block's nested structure.
 sea
-    : ID
+    : UNICODE_LATIN
+    | ID
+    | NAME
+    | DIGIT
+    | FILE
+    | FILES
+    | TEST_FIXTURES
+    | ENFORCED_PLATFORM
+    | PLATFORM
+    | PROJECT
     | PROJECT_ACCESSOR
+    | BUILDSCRIPT
+    | PATH
+    | CONFIGURATION
     | EQUALS
+    | SEMI
     | QUOTE_SINGLE
     | QUOTE_DOUBLE
     | PARENS_OPEN
     | PARENS_CLOSE
+    | BACKSLASH
+    | COMMA
+    ;
+
+// Balanced arguments keep create("Database") attached to its following block.
+callArguments
+    :   PARENS_OPEN callArgument* PARENS_CLOSE
+    ;
+
+// Argument values such as "Database" are grouped without interpreting their Groovy semantics.
+callArgument
+    :   callArguments
+    |   prefixedCallArguments
+    |   closure
+    |   callArgumentToken
+    ;
+
+// Lexer tokens such as files( include their opening parenthesis and only need a matching closing one.
+prefixedCallArguments
+    :   (FILE|FILES|TEST_FIXTURES|ENFORCED_PLATFORM|PLATFORM) callArgument* PARENS_CLOSE
+    ;
+
+callArgumentToken
+    :   UNICODE_LATIN
+    |   ID
+    |   NAME
+    |   DIGIT
+    |   PROJECT
+    |   PROJECT_ACCESSOR
+    |   BUILDSCRIPT
+    |   PATH
+    |   CONFIGURATION
+    |   EQUALS
+    |   SEMI
+    |   QUOTE_SINGLE
+    |   QUOTE_DOUBLE
+    |   BACKSLASH
+    |   COMMA
     ;

--- a/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
+++ b/gradle-script-grammar/src/test/groovy/com/autonomousapps/grammar/gradle/GradleScriptSpec.groovy
@@ -650,6 +650,99 @@ final class GradleScriptSpec extends Specification {
     )
   }
 
+  def "exposes blocks inside dependencies"() {
+    given:
+    def script = '''\
+      dependencies {
+        constraints {
+          runtime 'g:c:1'
+          api("g:b:1") {
+            because("Required by the Gradle plugin")
+          }
+          api libs.g.a
+        }
+        intellijPlatform {
+          instrumentationTools()
+          androidStudio libs.versions.androidStudio
+        }
+        implementation("g:z:1") {
+          because("Needed at runtime")
+        }
+      }
+      '''.stripIndent()
+
+    when:
+    def parsed = parseScript(script)
+    def dependencies = parsed.tree.dependencies()[0]
+    def constraints = dependencies.block()[0]
+    def intellijPlatform = dependencies.block()[1]
+    def apiConstraint = constraints.block()[0]
+
+    then:
+    assertThat(dependencies.block().collect { it.ID().text }).containsExactly(
+      'constraints',
+      'intellijPlatform',
+    ).inOrder()
+    assertThat(parsed.tokens.getText(constraints)).isEqualTo('''\
+      constraints {
+          runtime 'g:c:1'
+          api("g:b:1") {
+            because("Required by the Gradle plugin")
+          }
+          api libs.g.a
+        }'''.stripIndent())
+    assertThat(parsed.tokens.getText(intellijPlatform)).isEqualTo('''\
+      intellijPlatform {
+          instrumentationTools()
+          androidStudio libs.versions.androidStudio
+        }'''.stripIndent())
+    assertThat(apiConstraint.ID().text).isEqualTo('api')
+    assertThat(parsed.tokens.getText(apiConstraint.callArguments())).isEqualTo('("g:b:1")')
+    assertThat(dependencies.normalDeclaration().collect { it.configuration().text }).containsExactly('implementation')
+    assertThat(dependencies.normalDeclaration()[0].closure()).isNotNull()
+  }
+
+  def "exposes dotted and callable blocks"() {
+    given:
+    def script = '''\
+      android.sourceSets {
+        zeta()
+        files("libs/a.jar")
+        alpha()
+      }
+
+      sqldelight {
+        databases {
+          create("Database") {
+            zeta()
+            alpha()
+          }
+        }
+      }
+      '''.stripIndent()
+
+    when:
+    def parsed = parseScript(script)
+    def topLevelBlocks = parsed.tree.block()
+    def databases = topLevelBlocks[1].block()[0]
+    def createBlock = databases.block()[0]
+
+    then:
+    assertThat(topLevelBlocks.collect { it.ID().text }).containsExactly(
+      'android.sourceSets',
+      'sqldelight',
+    ).inOrder()
+    assertThat(databases.ID().text).isEqualTo('databases')
+    assertThat(databases.block()).hasSize(1)
+    assertThat(createBlock.ID().text).isEqualTo('create')
+    assertThat(parsed.tokens.getText(createBlock.callArguments())).isEqualTo('("Database")')
+    assertThat(parsed.tokens.getText(createBlock)).isEqualTo('''\
+      create("Database") {
+            zeta()
+            alpha()
+          }'''.stripIndent())
+  }
+
   @NamedVariant
   private void verifyDependency(
           def dep,
@@ -679,6 +772,20 @@ final class GradleScriptSpec extends Specification {
     walker.walk(listener, tree)
 
     return listener.list
+  }
+
+  private static Map<String, Object> parseScript(String script) {
+    def input = CharStreams.fromString(script)
+    def lexer = new GradleScriptLexer(input)
+    def tokens = new CommonTokenStream(lexer)
+    def parser = new GradleScript(tokens)
+    def errorListener = new SimpleANTLRErrorListener({ throw it })
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(errorListener)
+    parser.removeErrorListeners()
+    parser.addErrorListener(errorListener)
+
+    return [tree: parser.script(), tokens: tokens]
   }
 
   private static class GroovyGradleScriptListener extends GradleScriptBaseListener {


### PR DESCRIPTION
This is helpful for cases where the dependency-sorter plugin wants to look inside nested dependency-like blocks, and better support future custom dependencies-esque blocks.